### PR TITLE
Add automatic_reminders_settings relation to invoice

### DIFF
--- a/lib/billogram/resources/invoice.rb
+++ b/lib/billogram/resources/invoice.rb
@@ -19,6 +19,7 @@ module Billogram
 
     relation :items, :many
     relation :events, :many
+    relation :automatic_reminders_settings, :many, class_override: 'AutomaticReminder'
 
     COMMANDS = [ :sell, :remind, :collect, :writeoff, :resend, :remind, :payment, :credit, :message, :attach ]
 

--- a/spec/fixtures/billogram.json
+++ b/spec/fixtures/billogram.json
@@ -9,6 +9,9 @@
    "state" : "Unpaid",
    "attachment" : "orderdetails.pdf",
    "automatic_reminders" : true,
+   "automatic_reminders_settings": [
+     { "message" : "a lannister always pays his debts", "delay_days": 5 }
+   ],
    "rounding_value" : -0.25,
    "ocr_number" : "324810046924",
    "events" : [

--- a/spec/resources/invoice_spec.rb
+++ b/spec/resources/invoice_spec.rb
@@ -39,6 +39,9 @@ describe Billogram::Invoice do
       its(:callbacks) { is_expected.to be_a(Billogram::Callbacks) }
       its(:detailed_sums) { is_expected.to be_a(Billogram::DetailedSums) }
       its(:regional_sweden) { is_expected.to be_a(Billogram::RegionalSweden) }
+      its(:automatic_reminders_settings) {
+        is_expected.to include(Billogram::AutomaticReminder)
+      }
     end
 
     it { is_expected.to respond_to(:id) }


### PR DESCRIPTION
The current API includes `automatic_reminders_settings` in the response body for billogram which raises `undefined method automatic_reminders_settings= for #<Billogram::Invoice:0x007f99c98614a0>"`