### PR TITLE
Add support for ruby 3.* and active support 6.*

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4.x',  '2.5.x',  '2.6.x', '2.7.x', '3.0.x' ]
+        ruby: [ '2.5.x',  '2.6.x', '2.7.x', '3.0.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4.x',  '2.5.x',  '2.6.x' ]
+        ruby: [ '2.4.x',  '2.5.x',  '2.6.x', '2.7.x', '3.0.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     - "*"
     tags:
     - "!*"
+  pull_request:
+    branches:
+    - "*"
 
 jobs:
   bundler:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5.x',  '2.6.x', '2.7.x', '3.0.x' ]
+        ruby: [ '2.5',  '2.6', '2.7', '3.0' ]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Set up Bundler
-      run: gem install bundler -v 1.17.3
-    - name: Install dependencies
-      run: bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run tests
       run: bundle exec rspec

--- a/billogram.gemspec
+++ b/billogram.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4', '< 4'
+  spec.required_ruby_version = '>= 2.5', '< 4'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/billogram.gemspec
+++ b/billogram.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4', '< 4'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
 
   spec.add_dependency "httparty", "~> 0.17.1"
-  spec.add_dependency "activesupport", "~> 5.2"
+  spec.add_dependency "activesupport", ">= 5.2", "< 7"
 end

--- a/lib/billogram/resources/invoice.rb
+++ b/lib/billogram/resources/invoice.rb
@@ -4,7 +4,7 @@ module Billogram
 
     endpoint 'billogram'
 
-    attr_accessor :id, :invoice_no, :ocr_number, :invoice_date, :due_date, :due_days, 
+    attr_accessor :id, :invoice_no, :ocr_number, :invoice_date, :due_date, :due_days,
                   :invoice_fee, :invoice_fee_vat, :reminder_fee, :interest_rate,
                   :interest_fee, :currency, :delivery_method, :state, :url, :flags,
                   :remaining_sum, :total_sum, :rounding_value, :automatic_reminders,

--- a/spec/relation_spec.rb
+++ b/spec/relation_spec.rb
@@ -2,22 +2,20 @@ require 'spec_helper'
 
 describe Billogram::Relation do
   describe "#relation_class" do
-    subject { described_class.new(*params).relation_class }
-
     describe "one" do
-      let(:params) { [:customer, :one] }
+      subject { described_class.new(:customer, :one).relation_class }
 
       it { is_expected.to eq(Billogram::Customer) }
     end
 
     describe "many" do
-      let(:params) { [:items, :many] }
+      subject { described_class.new(:items, :many).relation_class }
 
       it { is_expected.to eq(Billogram::Item) }
     end
 
     describe "with class override" do
-      let(:params) { [:invoices, :one, class_override: "InvoiceDefaults"] }
+      subject { described_class.new(:invoices, :one, class_override: "InvoiceDefaults").relation_class }
 
       it { is_expected.to eq(Billogram::InvoiceDefaults) }
     end

--- a/spec/resources/invoice_spec.rb
+++ b/spec/resources/invoice_spec.rb
@@ -11,7 +11,7 @@ describe Billogram::Invoice do
         path = "billogram/#{subject.id}/command/send"
         options = { method: 'Email' }
         expect(described_class).to receive(:perform_request).with(:post, path, options)
-        subject.send!(options)
+        subject.send!(**options)
       end
     end
 


### PR DESCRIPTION
Installing the gem on ruby 3.0 installs version 0.3.1 since that's the latest version without ruby version specified in the Gemfile.