### PR TITLE
Add new attributes on invoice sub-objects

### DIFF
--- a/lib/billogram/resources/automatic_collection.rb
+++ b/lib/billogram/resources/automatic_collection.rb
@@ -1,5 +1,5 @@
 module Billogram
   class AutomaticCollection < Resource
-    attr_accessor :delay_days, :amount
+    attr_accessor :delay_days, :amount, :use_default_settings
   end
 end

--- a/lib/billogram/resources/edi.rb
+++ b/lib/billogram/resources/edi.rb
@@ -1,5 +1,5 @@
 module Billogram
   class Edi < Resource
-    attr_accessor :electronic_id, :operator, :subtype, :reference
+    attr_accessor :electronic_id, :operator, :subtype, :reference, :note
   end
 end

--- a/spec/support/fixtures/billogram.json
+++ b/spec/support/fixtures/billogram.json
@@ -115,6 +115,7 @@
   },
   "automatic_collection" : {
     "delay_days" : 6,
-    "amount" : 60
+    "amount" : 60,
+    "use_default_settings": false
   }
 }


### PR DESCRIPTION
I'm not sure these is not more missing attributes on other objects, but these two appeared missing when testing to create an invoice using the lib so figured it would be good to add them.
